### PR TITLE
Made opencv-python dependency optional (Fixes #45) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,15 @@ Compared to these existed solutions, DXcam provides:
 ```bash
 pip install dxcam
 ```
+
+**Note:** OpenCV is required by DXcam for colorspace conversion. If you don't already have OpenCV, install it easily with command `pip install dxcam[cv2]`.
+
 ### From source:
 ```bash
 pip install --editable .
+
+# for installing OpenCV also
+pip install --editable .[cv2]
 ```
 
 ## Usage

--- a/examples/capture_to_video.py
+++ b/examples/capture_to_video.py
@@ -1,4 +1,6 @@
 import dxcam
+
+# install OpenCV using `pip install dxcam[cv2]` command.
 import cv2
 
 TOP = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,8 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     numpy
-    opencv-python
     comtypes
-
+[options.extras_require]
+cv2 = opencv-python
 [options.packages.find]
 include = dxcam*


### PR DESCRIPTION
This PR will fix #45 and make `opencv-python` dependency installation optional by, so that User can now install `opencv-python` dependency along with `dxcam` using command `pip install dxcam[cv2]`, only when required.