### PR TITLE
Performance improvement of numpy processor for BGRA->BGR and BGRA->RGB conversion

### DIFF
--- a/dxcam/processor/numpy_processor.py
+++ b/dxcam/processor/numpy_processor.py
@@ -13,21 +13,17 @@ class NumpyProcessor(Processor):
 
         # only one time process
         if self.cvtcolor is None:
-            color_mapping = {
-                "RGB": cv2.COLOR_BGRA2RGB,
-                "RGBA": cv2.COLOR_BGRA2RGBA,
-                "BGR": cv2.COLOR_BGRA2BGR,
-                "GRAY": cv2.COLOR_BGRA2GRAY,
-                "BGRA": None,
-            }
-            cv2_code = color_mapping[self.color_mode]
-            if cv2_code is not None:
-                if cv2_code != cv2.COLOR_BGRA2GRAY:
-                    self.cvtcolor = lambda image: cv2.cvtColor(image, cv2_code)
+            if self.color_mode!="BGRA":
+                if self.color_mode=="BGR":
+                    self.cvtcolor = lambda image: image[:,:,:3] #BGRA -> BGR conversion
+                elif self.color_mode=='RGB':
+                    self.cvtcolor = lambda image: np.flip(image[:,:,:3],axis=-1) #BGRA -> RGB conversion
+                elif self.color_mode=='RGBA':
+                    self.cvtcolor = lambda image: cv2.cvtColor(image, cv2.COLOR_BGRA2RGBA)
                 else:
-                    self.cvtcolor = lambda image: cv2.cvtColor(image, cv2_code)[
+                    self.cvtcolor = lambda image: cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)[
                         ..., np.newaxis
-                    ]
+                    ] 
             else:
                 return image
         return self.cvtcolor(image)


### PR DESCRIPTION
In profiling a benchmark code this takes processing overhead from ~14% to ~1.4% and ~0.06% respectively.
I was not able to measure significant FPS improvements because I am limited by the refresh rate of my screen rather than by dxcam itself.

Benchmarking code I profiled
`import dxcam
import time

start_time, fps = time.perf_counter(), 0
	cam = dxcam.create(output_color=Colors[2])
	start = time.perf_counter()
	while fps < 1000:
	    frame = cam.grab()
	    if frame is not None:  # New frame
	        fps += 1
	end_time = time.perf_counter() - start_time
	print(fps/end_time)`

Correctness checking code
`import dxcam
import cv2
def get_frame(cam):
	img = None
	while img is None:
		img = cam.grab()
	return img
color_mapping = {
    "RGB": cv2.COLOR_BGRA2RGB,
    "BGR": cv2.COLOR_BGRA2BGR,
}
for c in ["BGR", "RGB"]:
	cam = dxcam.create(output_color=c)
	img = get_frame(cam)
	cam.release()
	del cam
	cam = dxcam.create(output_color='BGRA')
	img2 = get_frame(cam)
	img2 = cv2.cvtColor(img2, color_mapping[c])
	print(img.shape,img2.shape)
	print((img!=img2).sum())
	cam.release()
	del cam`