### PR TITLE
Fixes the error where, if a user tries to get the latest frame without starting the camera, the program gets blocked indefinitely

### DIFF
--- a/dxcam/dxcam.py
+++ b/dxcam/dxcam.py
@@ -147,6 +147,9 @@ class DXCamera:
         self.__stop_capture.clear()
 
     def get_latest_frame(self):
+        if not self.is_capturing:
+            raise capture_error(
+                'camera is not started. camera.get_latest_frame unavailable.\nDid you forgot to run camera.start?')
         self.__frame_available.wait()
         with self.__lock:
             ret = self.__frame_buffer[(self.__head - 1) % self.max_buffer_len]


### PR DESCRIPTION
I came across this
```py
import dxcam
camera = dxcam.create()
frame = camera.get_latest_frame() #blockes the program forever.
```
It took me a while to figure out what had just happened.

Novices frequently make this mistake.

Now it will raise an error.